### PR TITLE
Fixed --to-gdb to handle readline, amongst other problems

### DIFF
--- a/shellnoob.py
+++ b/shellnoob.py
@@ -564,7 +564,7 @@ int main() {
             print('------------------------', file=sys.stderr)
 
         if start_addr:
-            cmd = '(echo "break *%s"; cat) | gdb -q %s' % (start_addr, exe_fp)
+            cmd = 'gdb -ex "break *%s" -q %s' % (start_addr, exe_fp)
         else:
             cmd = 'gdb -q %s' % exe_fp
         p = Popen(cmd, shell=True)


### PR DESCRIPTION
Catting input to gdb breaks some gdb plugins (can't run /usr/bin/tty to get the dimensions of the terminal, for instance). It also breaks readline entirely, as well as the ability to quit gdb using its quit command. Passing in the break command as an argument to gdb fixes all that, which is what I've done. It's a small change, but it helps a ton in smoothing out workflow.