### PR TITLE
Fix exceptions when outputting to sys.stdout

### DIFF
--- a/shellnoob.py
+++ b/shellnoob.py
@@ -533,7 +533,7 @@ int main() {
             _output = cbytes(_output)
         # writing the output
         if output_fp == '-':
-            sys.stdout.write(_output)
+            sys.stdout.write(_output.decode(sys.stdout.encoding))
         else:
             open(output_fp, 'wb').write(_output)
 


### PR DESCRIPTION
To repro, run:

`python3 shellnoob.py --intel --64 --from-asm some_file.S --to-c -`

Got the following error:
```
Traceback (most recent call last):
  File "shellnoob.py", line 1564, in <module>
    main()
  File "shellnoob.py", line 1560, in main
    snoob.do_conversion(input_fp, output_fp, input_fmt, output_fmt)
  File "shellnoob.py", line 536, in do_conversion
    sys.stdout.write(_output)
TypeError: write() argument must be str, not bytes
```
Tested with python 2.7.18 and python 3.7.4
